### PR TITLE
Updated conditionals to fix template errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,17 +34,17 @@
 
 - name: Reload systemd daemon
   command: "systemctl daemon-reload"
-  when: iptables_register_unit | changed
+  when: iptables_register_unit.changed
 
 - name: Restart iptables service
   service:
     name: "iptables-restore"
     state: "restarted"
     enabled: True
-  when: iptables_register_config | changed
+  when: iptables_register_config.changed
 
 - name: Restart dependent services
   shell: test -f {{ item.path }}/{{ item.name }}.service \
          && systemctl restart {{ item.name }}.service || true
   with_items: "{{ iptables_restart_dependent_services }}"
-  when: iptables_restart_dependent_services and iptables_register_config | changed
+  when: iptables_restart_dependent_services and iptables_register_config.changed


### PR DESCRIPTION
On Ansible v2.9.0, when running this role I got:

> The error was: template error while templating string: no filter named 'changed'.

Fixed it by using the `changed` key in `iptables_register_unit` instead of using a filter.